### PR TITLE
feat: add support for team id argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## now-purge
+
+## Unreleased
+
+- feat: add support for team id argument

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Commands:
   n  name in package.json or now.json to filter your deployments
 
 Options:
+  --team, -m     team id
   -h, --help     Show help                                             [boolean]
   -v, --version  Show version number                                   [boolean]
 ```
@@ -43,7 +44,8 @@ const nowPurge = require('now-purge')
 // optional config parameters
 const config = {
   token: 'YOUR_NOW_TOKEN',
-  deploymentName: 'test'
+  deploymentName: 'test',
+  team: 'OPTION_TEAM_ID',
 }
 
 nowPurge(config)
@@ -55,7 +57,7 @@ You can remove your oldest deployments without an alias
 
 ```bash
 npm install -g now-purge
-now-purge -t YOUR_NOW_TOKEN -n YOUR_NOW_OR_PACKAGE_NAME
+now-purge -t YOUR_NOW_TOKEN -n YOUR_NOW_OR_PACKAGE_NAME --team OPTION_TEAM_ID
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -6,13 +6,17 @@ const argv = require('yargs')
       .usage('Usage: $0 <command> [options]')
       .command('t', 'now token')
       .command('n', 'name in package.json or now.json to filter your deployments')
+      .option('team', {
+        alias: 'm',
+        describe: 'team id'
+      })
       .help('h')
       .alias('h', 'help')
       .version(() => libVersion)
       .alias('v', 'version')
       .argv
 
-const nowClient = require('now-client')
+const NowClient = require('now-client')
 
 let now
 
@@ -37,7 +41,7 @@ const removeDeployments = (deployments) => {
 
 // you can pass your `package.json` or `now.json` `name` to filter your deployments
 const main = (config = {}) => {
-  now = nowClient(argv.t || config.token)
+  now = new NowClient(argv.t || config.token, argv.team || config.team)
   getDeploymentsWithoutAlias(argv.n || config.deploymentName)
   .then(deployments => removeDeployments(deployments))
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Matias Tucci <matiastucci@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "now-client": "^0.7.0",
+    "now-client": "^1.1.1",
     "yargs": "^7.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades the `now-client` to `v1.1.1`, and support for `teamId` argument.

```
-- team 'id'
```